### PR TITLE
add `object-property-newline` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,7 @@ module.exports = {
 		'no-trailing-spaces': 2,
 		'no-unneeded-ternary': 2,
 		'object-curly-spacing': [2, 'never'],
+		'object-property-newline': 2,
 		'one-var': [2, 'never'],
 		'one-var-declaration-per-line': 2,
 		'operator-assignment': [2, 'always'],

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
   "devDependencies": {
     "ava": "*",
     "babel-eslint": "^6.0.0",
-    "eslint": "^2.9.0",
+    "eslint": "^2.10.1",
     "eslint-plugin-babel": "^3.0.0",
     "is-plain-obj": "^1.0.0",
     "temp-write": "^2.1.0"
   },
   "peerDependencies": {
-    "eslint": ">=2.9.0"
+    "eslint": ">=2.10.0"
   }
 }


### PR DESCRIPTION
http://eslint.org/docs/rules/object-property-newline

I think it's a good change. It will require object literals with more than one key to be multi-line. This is beneficial for both readability and diffs.

Thoughts?

-

// @kevva @SamVerschueren @jamestalmage @vdemedes