### PR TITLE
Add `no-mixed-operators` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@ module.exports = {
 		'no-useless-rename': 2,
 		'require-yield': 2,
 		'template-curly-spacing': 2,
-		'yield-star-spacing': [2, 'both']
+		'yield-star-spacing': [2, 'both'],
+		'no-mixed-operators': [2, {'allowSamePrecedence': true}]
 	}
 };


### PR DESCRIPTION
Add `no-mixed-operators` rule, following its addition in ESLint 2.12.0.
Don't know if you want to limit this to only logical and/or mathematical operators, not sure of the impact that this will have. What do you think?