### PR TITLE
linebreak-style makes it impossible for Windows users to contribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,6 @@ module.exports = {
 			afterColon: true
 		}],
 		'keyword-spacing': 'error',
-		'linebreak-style': ['error', 'unix'],
 		'max-depth': 'warn',
 		'max-nested-callbacks': ['warn', 4],
 		'max-params': ['warn', {


### PR DESCRIPTION
Any project that currently uses eslint-config-xo checked out on Windows results in thousands of linter errors since the line endings will be CRLF, making it impossible to contribute to these projects as a Windows user without nerfing the linter entirely.

A better way to enforce this is not via a linter, but via a .gitattributes file (https://help.github.com/articles/dealing-with-line-endings). When you do this, Git will ensure the repo internally is LF, but on Win32 will check out files as CRLF (this is a builtin case of a clean/smudge filter)

Refs https://github.com/zeit/hyper/pull/1230