### PR TITLE
Disable `linebreak-style` on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,6 @@ module.exports = {
 			afterColon: true
 		}],
 		'keyword-spacing': 'error',
-		'linebreak-style': ['error', 'unix'],
 		'max-depth': 'warn',
 		'max-nested-callbacks': ['warn', 4],
 		'max-params': ['warn', {

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ module.exports = {
 			afterColon: true
 		}],
 		'keyword-spacing': 'error',
-    'linebreak-style': [(process.platform === 'win32' ? 'off' : 'error'), 'unix'],
+		'linebreak-style': [(process.platform === 'win32' ? 'off' : 'error'), 'unix'],
 		'lines-between-class-members': ['error', 'always'],
 		'max-depth': 'warn',
 		'max-nested-callbacks': ['warn', 4],


### PR DESCRIPTION
git autocrlf will cause errors by default on all windows machines with this. This means that xo, by default, contrasts with git's defaults and needs further config on every Windows machine.

Fixes https://github.com/sindresorhus/xo/issues/171