### PR TITLE
Disable `camelrule` on `properties`

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ module.exports = {
 			allowSingleLine: false
 		}],
 		camelcase: ['error', {
-			properties: 'always'
+			properties: 'never'
 		}],
 		'capitalized-comments': ['error', 'always', {
 			// You can also ignore this rule by wrapping the first word in quotes


### PR DESCRIPTION
The [camelcase](https://eslint.org/docs/rules/camelcase) rule creates a lot of false positive when dealing with API/Third-parties that use snake case properties.

For example, [creating a release on Github](https://developer.github.com/v3/repos/releases/#create-a-release):
```js
const GitHubApi = require('github');

const github = new GitHubApi();
const release = {
  owner: 'sindresorhus',
  repo: 'xo',
  tag_name: 'v1.0.0',
  name: 'v1.0.0',
  target_commitish: 'master'
};
const {data: {html_url}} = await github.repos.createRelease(release);
```
The rule will report errors on `tag_name`, `target_commitish` and `html_url`.
In the case of `html_url` it could be rewritten `const {data: {html_url: htmlUrl}}` but in the case of `tag_name` and `target_commitish` there is no much that can be done as it is required by the API.

Generally, it's quite common to use `Object` with properties that are defined by things out of the developer control (REST API, JS modules, Database etc...). So enforcing camelcase on object properties is more often problematic than not. 
